### PR TITLE
Fix Infinite scroll on pass by swiping the card left 

### DIFF
--- a/app/src/main/java/com/eillia/ehya/ui/components/DraggableCard.kt
+++ b/app/src/main/java/com/eillia/ehya/ui/components/DraggableCard.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.graphicsLayer
@@ -86,6 +87,7 @@ fun DraggableCard(
   }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 fun Modifier.dragContent(
   swipeX: Animatable<Float, AnimationVector1D>,
   swipeY: Animatable<Float, AnimationVector1D>,
@@ -116,7 +118,7 @@ fun Modifier.dragContent(
         }
       }
     ) { change, dragAmount ->
-      change.consumePositionChange()
+      change.consume()
       coroutineScope.launch {
         swipeX.animateTo(swipeX.targetValue + dragAmount.x)
         swipeY.animateTo(swipeY.targetValue + dragAmount.y)

--- a/app/src/main/java/com/eillia/ehya/ui/components/DraggableCard.kt
+++ b/app/src/main/java/com/eillia/ehya/ui/components/DraggableCard.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.consumePositionChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
@@ -36,6 +35,7 @@ import com.eillia.ehya.model.data.entity.Sunnah
 import com.eillia.ehya.ui.theme.BottomSheetShape
 import com.eillia.ehya.viewmodels.SwipeResult
 import kotlin.math.abs
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /*
@@ -52,6 +52,7 @@ fun DraggableCard(
 ) {
   val configuration = LocalConfiguration.current
   val screenWidth = configuration.screenWidthDp.dp
+  val coroutineScope = rememberCoroutineScope()
   val swipeXLeft = -(screenWidth.value * 3.2).toFloat()
   val swipeXRight = (screenWidth.value * 3.2).toFloat()
   val swipeYTop = -1000f
@@ -75,8 +76,7 @@ fun DraggableCard(
           swipeX = swipeX,
           swipeY = swipeY,
           maxX = swipeXRight,
-          onSwiped = { _, _ ->
-          }
+          coroutineScope,
         )
         .then(graphicLayer)
     ) {
@@ -84,8 +84,8 @@ fun DraggableCard(
     }
   } else {
     val swipeResult = if (swipeX.value > 0) SwipeResult.TRY else SwipeResult.PASS
-    LaunchedEffect(key1 = true){
-    onSwiped(swipeResult, item)
+    LaunchedEffect(key1 = true) {
+      onSwiped(swipeResult, item)
     }
   }
 }
@@ -95,9 +95,8 @@ fun Modifier.dragContent(
   swipeX: Animatable<Float, AnimationVector1D>,
   swipeY: Animatable<Float, AnimationVector1D>,
   maxX: Float,
-  onSwiped: (Any, Any) -> Unit
+  coroutineScope: CoroutineScope
 ): Modifier = composed {
-  val coroutineScope = rememberCoroutineScope()
   pointerInput(Unit) {
     this.detectDragGestures(
       onDragCancel = {
@@ -116,6 +115,8 @@ fun Modifier.dragContent(
               swipeX.animateTo(maxX, tween(400))
             } else {
               swipeX.animateTo(-maxX, tween(400))
+              swipeX.animateTo(0f)
+              swipeY.animateTo(0f)
             }
           }
         }

--- a/app/src/main/java/com/eillia/ehya/ui/components/DraggableCard.kt
+++ b/app/src/main/java/com/eillia/ehya/ui/components/DraggableCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -83,7 +84,9 @@ fun DraggableCard(
     }
   } else {
     val swipeResult = if (swipeX.value > 0) SwipeResult.TRY else SwipeResult.PASS
+    LaunchedEffect(key1 = true){
     onSwiped(swipeResult, item)
+    }
   }
 }
 

--- a/app/src/main/java/com/eillia/ehya/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/com/eillia/ehya/viewmodels/AppViewModel.kt
@@ -78,7 +78,7 @@ class AppViewModel @Inject constructor(
   }
 
   fun onSwipe(swipeResult: SwipeResult, sunnah: Sunnah) = viewModelScope.launch {
-    if ((swipeResult == SwipeResult.PASS) && (appRepository.isPassed(sunnah.id) == null)) {
+    if (swipeResult == SwipeResult.PASS) {
       passSunnah(sunnah)
       Timber.d("swiped pass $swipeResult")
     } else if ((swipeResult == SwipeResult.TRY) && (appRepository.isTried(sunnah.id) == null)) {


### PR DESCRIPTION
# Description

This issue took a lot of analysis I'll be honest!

1 - DraggableCard Composable

The infinite swipe can be solved using a Launched effect to prevent onSwipe to keep running on recomposition, When the View model shuffles the cards. 

But this introduces 2 new issues 

  1 - The draggable card approach implemented from  [Compose Cook Book](https://github.com/Gurupreet/ComposeCookBook) Uses a one time use of cards. While in Context of Ehya Application Passing the cards should not remove them from the playing field.

  So That's the first issue **The passed cards get removed**

  Fix: When the card is swiped left (passed), I Implemented an animation to bring it back to the screen. which can be seen on line 118-119 (Please if necessary, modify Timings by adding tween to your liking) 

  2 - The second issue was that when the card was passed, The view model would check if it was passed in appRepository, which introduces unnecessary check that does not happen when the pass arrow is clicked, This gives us an issue. If a card is passed it will not shuffle the cards. 
  
  Fix: Remove all appRepository.isPassed / isTried checks. inside onSwipe (View model) and the onSwipe function of the view model should only redirect the Swipe result to the passSunnah / trySunnah. This is to prevent inconsistent results between swiping or clicking the arrows


# Fixes # (issue)

This fixes #3 
